### PR TITLE
Revert "chore(deps): update container image k8s.gcr.io/metrics-server/metrics-server to v0.5.2"

### DIFF
--- a/cluster/apps/kube-system/metrics-server/kustomization.yaml
+++ b/cluster/apps/kube-system/metrics-server/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 images:
   - name: gcr.io/k8s-staging-metrics-server/metrics-server
     newName: k8s.gcr.io/metrics-server/metrics-server
-    newTag: v0.5.2
+    newTag: v0.5.1
 patchesStrategicMerge:
   - |-
     apiVersion: apps/v1


### PR DESCRIPTION
Reverts seblaporte/k3s-at-home#61