### PR TITLE
feat: add HelmRelease remediation strategy to all apps

### DIFF
--- a/cluster/apps/adguard-home/helm-release.yaml
+++ b/cluster/apps/adguard-home/helm-release.yaml
@@ -17,6 +17,13 @@ spec:
         name: k8s-at-home-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     image:
       repository: adguard/adguardhome

--- a/cluster/apps/aiconnect/helm-release.yaml
+++ b/cluster/apps/aiconnect/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       hostNetwork: true

--- a/cluster/apps/backrest/helm-release.yaml
+++ b/cluster/apps/backrest/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/esphome/helm-release.yaml
+++ b/cluster/apps/esphome/helm-release.yaml
@@ -16,6 +16,13 @@ spec:
         name: k8s-at-home-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     image:
       repository: esphome/esphome

--- a/cluster/apps/flaresolverr/helm-release.yaml
+++ b/cluster/apps/flaresolverr/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/go2rtc/helm-release.yaml
+++ b/cluster/apps/go2rtc/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/heimdall/helm-release.yaml
+++ b/cluster/apps/heimdall/helm-release.yaml
@@ -16,6 +16,13 @@ spec:
         name: k8s-at-home-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     ingress:
       main:

--- a/cluster/apps/home-assistant/helm-release.yaml
+++ b/cluster/apps/home-assistant/helm-release.yaml
@@ -16,6 +16,13 @@ spec:
         name: k8s-at-home-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/influxdb-home-assistant/helm-release.yaml
+++ b/cluster/apps/influxdb-home-assistant/helm-release.yaml
@@ -16,6 +16,13 @@ spec:
         name: influxdata-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     persistence:
       enabled: true

--- a/cluster/apps/jellyfin/helm-release.yaml
+++ b/cluster/apps/jellyfin/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       hostNetwork: true

--- a/cluster/apps/jellyseerr/helm-release.yaml
+++ b/cluster/apps/jellyseerr/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/joal/helm-release.yaml
+++ b/cluster/apps/joal/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/kitchenvault/base/helm-release-backend.yaml
+++ b/cluster/apps/kitchenvault/base/helm-release-backend.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/kitchenvault/base/helm-release-cookidoo.yaml
+++ b/cluster/apps/kitchenvault/base/helm-release-cookidoo.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/kitchenvault/base/helm-release-frontend.yaml
+++ b/cluster/apps/kitchenvault/base/helm-release-frontend.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/kitchenvault/base/helm-release-postgres.yaml
+++ b/cluster/apps/kitchenvault/base/helm-release-postgres.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/lidarr/helm-release.yaml
+++ b/cluster/apps/lidarr/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/maintainerr/helm-release.yaml
+++ b/cluster/apps/maintainerr/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/memos/helm-release.yaml
+++ b/cluster/apps/memos/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/minio/helm-release.yaml
+++ b/cluster/apps/minio/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       hostNetwork: true

--- a/cluster/apps/mosquitto/helm-release.yaml
+++ b/cluster/apps/mosquitto/helm-release.yaml
@@ -16,6 +16,13 @@ spec:
         name: k8s-at-home-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     image:
       repository: eclipse-mosquitto

--- a/cluster/apps/music-assistant/helm-release.yaml
+++ b/cluster/apps/music-assistant/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       hostNetwork: true

--- a/cluster/apps/navidrome/helm-release.yaml
+++ b/cluster/apps/navidrome/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       nodeSelector:

--- a/cluster/apps/networking/authelia/helm-release.yaml
+++ b/cluster/apps/networking/authelia/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       enableServiceLinks: false

--- a/cluster/apps/networking/crowdsec/helm-release.yaml
+++ b/cluster/apps/networking/crowdsec/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: crowdsec-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   dependsOn:
     - name: cert-manager
       namespace: cert-manager

--- a/cluster/apps/networking/traefik/helm-release.yaml
+++ b/cluster/apps/networking/traefik/helm-release.yaml
@@ -16,6 +16,13 @@ spec:
         name: traefik-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   dependsOn:
     - name: cert-manager
       namespace: cert-manager

--- a/cluster/apps/node-red/helm-release.yaml
+++ b/cluster/apps/node-red/helm-release.yaml
@@ -16,6 +16,13 @@ spec:
         name: k8s-at-home-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     image:
       repository: nodered/node-red

--- a/cluster/apps/obsidian-couchdb/helm-release.yaml
+++ b/cluster/apps/obsidian-couchdb/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/prowlarr/helm-release.yaml
+++ b/cluster/apps/prowlarr/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/radarr/helm-release.yaml
+++ b/cluster/apps/radarr/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/scrypted/helm-release.yaml
+++ b/cluster/apps/scrypted/helm-release.yaml
@@ -16,6 +16,13 @@ spec:
         name: k8s-at-home-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     image:
       repository: koush/scrypted

--- a/cluster/apps/shopping-cards/helm-release.yaml
+++ b/cluster/apps/shopping-cards/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       imagePullSecrets:

--- a/cluster/apps/slskd/helm-release.yaml
+++ b/cluster/apps/slskd/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/sonarr/helm-release.yaml
+++ b/cluster/apps/sonarr/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/teleinfo2mqtt/helm-release.yaml
+++ b/cluster/apps/teleinfo2mqtt/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       nodeSelector:

--- a/cluster/apps/tesla-fleet/helm-release.yaml
+++ b/cluster/apps/tesla-fleet/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/teslamate/helm-release-backend.yaml
+++ b/cluster/apps/teslamate/helm-release-backend.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/teslamate/helm-release-grafana.yaml
+++ b/cluster/apps/teslamate/helm-release-grafana.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/transmission/helm-release.yaml
+++ b/cluster/apps/transmission/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/tvheadend/helm-release.yaml
+++ b/cluster/apps/tvheadend/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       nodeSelector:

--- a/cluster/apps/tydom2mqtt/helm-release.yaml
+++ b/cluster/apps/tydom2mqtt/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/unifi/helm-release.yaml
+++ b/cluster/apps/unifi/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/unpoller/helm-release.yaml
+++ b/cluster/apps/unpoller/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     controllers:
       main:

--- a/cluster/apps/uptime-kuma/helm-release.yaml
+++ b/cluster/apps/uptime-kuma/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     controllers:
       main:

--- a/cluster/apps/vaultwarden/helm-release.yaml
+++ b/cluster/apps/vaultwarden/helm-release.yaml
@@ -16,6 +16,13 @@ spec:
         name: k8s-at-home-charts
         namespace: flux-system
       interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     image:
       repository: vaultwarden/server

--- a/cluster/apps/ygege/helm-release.yaml
+++ b/cluster/apps/ygege/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/yubal/helm-release.yaml
+++ b/cluster/apps/yubal/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       affinity:

--- a/cluster/apps/zigbee2mqtt/helm-release.yaml
+++ b/cluster/apps/zigbee2mqtt/helm-release.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
       interval: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       nodeSelector:


### PR DESCRIPTION
## Problème identifié

Aucun des 48 HelmReleases du cluster ne définissait de stratégie de remediation (`install.remediation` / `upgrade.remediation`). En cas d'échec d'installation ou de mise à jour d'un chart Helm, Flux CD reste bloqué indéfiniment dans l'état `Failed` sans tenter de récupération automatique.

## Solution

Ajout d'une stratégie de remediation standard sur l'ensemble des HelmReleases :

```yaml
install:
  remediation:
    retries: 3
upgrade:
  remediation:
    retries: 3
    remediateLastFailure: true
```

- **3 tentatives** avant d'abandonner
- **`remediateLastFailure: true`** : rollback automatique vers la dernière version stable en cas d'échec de mise à jour

## Impact

Amélioration de la résilience de Flux CD : les déploiements échoués seront automatiquement retentés et, si nécessaire, annulés proprement.

## Fichiers modifiés

48 fichiers `helm-release.yaml` dans `cluster/apps/`