### PR TITLE
feat: add liveness and readiness probes to all apps

### DIFF
--- a/cluster/apps/adguard-home/helm-release.yaml
+++ b/cluster/apps/adguard-home/helm-release.yaml
@@ -83,6 +83,29 @@ spec:
         accessMode: "ReadWriteOnce"
         mountPath: /opt/adguardhome/work
         size: "2Gi"
+    probes:
+      liveness:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+      readiness:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
     resources:
       requests:
         cpu: 25m

--- a/cluster/apps/backrest/helm-release.yaml
+++ b/cluster/apps/backrest/helm-release.yaml
@@ -54,6 +54,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/esphome/helm-release.yaml
+++ b/cluster/apps/esphome/helm-release.yaml
@@ -55,6 +55,27 @@ spec:
         accessMode: "ReadWriteOnce"
         mountPath: /config
         size: "1Gi"
+    probes:
+      liveness:
+        enabled: true
+        custom: true
+        spec:
+          tcpSocket:
+            port: 6052
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+      readiness:
+        enabled: true
+        custom: true
+        spec:
+          tcpSocket:
+            port: 6052
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
     resources:
       requests:
         memory: 250Mi

--- a/cluster/apps/flaresolverr/helm-release.yaml
+++ b/cluster/apps/flaresolverr/helm-release.yaml
@@ -54,6 +54,20 @@ spec:
                   ## This means it has a maximum of 8*60=480 seconds to start up before it fails
                   periodSeconds: 8
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/heimdall/helm-release.yaml
+++ b/cluster/apps/heimdall/helm-release.yaml
@@ -50,6 +50,29 @@ spec:
         accessMode: "ReadWriteOnce"
         mountPath: /config
         size: "1Gi"
+    probes:
+      liveness:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+      readiness:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
     resources:
       requests:
         memory: 196Mi

--- a/cluster/apps/home-assistant/helm-release.yaml
+++ b/cluster/apps/home-assistant/helm-release.yaml
@@ -70,6 +70,26 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 5
           failureThreshold: 100
+      liveness:
+        enabled: true
+        custom: true
+        spec:
+          tcpSocket:
+            port: 8123
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+      readiness:
+        enabled: true
+        custom: true
+        spec:
+          tcpSocket:
+            port: 8123
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
     ingress:
       main:
         enabled: true

--- a/cluster/apps/jellyfin/helm-release.yaml
+++ b/cluster/apps/jellyfin/helm-release.yaml
@@ -52,11 +52,27 @@ spec:
                   periodSeconds: 5
                   failureThreshold: 60
               liveness:
+                enabled: true
+                custom: true
                 spec:
+                  httpGet:
+                    path: /health
+                    port: 8096
                   initialDelaySeconds: 0
                   timeoutSeconds: 1
                   periodSeconds: 60
                   failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8096
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/jellyseerr/helm-release.yaml
+++ b/cluster/apps/jellyseerr/helm-release.yaml
@@ -50,6 +50,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/joal/helm-release.yaml
+++ b/cluster/apps/joal/helm-release.yaml
@@ -59,6 +59,20 @@ spec:
                   ## This means it has a maximum of 8*60=480 seconds to start up before it fails
                   periodSeconds: 8
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/kitchenvault/base/helm-release-backend.yaml
+++ b/cluster/apps/kitchenvault/base/helm-release-backend.yaml
@@ -54,6 +54,21 @@ spec:
               limits:
                 memory: 768Mi
                 cpu: 500m
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/kitchenvault/base/helm-release-frontend.yaml
+++ b/cluster/apps/kitchenvault/base/helm-release-frontend.yaml
@@ -43,6 +43,21 @@ spec:
               limits:
                 memory: 128Mi
                 cpu: 100m
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/lidarr/helm-release.yaml
+++ b/cluster/apps/lidarr/helm-release.yaml
@@ -52,6 +52,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/maintainerr/helm-release.yaml
+++ b/cluster/apps/maintainerr/helm-release.yaml
@@ -67,6 +67,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/memos/helm-release.yaml
+++ b/cluster/apps/memos/helm-release.yaml
@@ -53,6 +53,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/minio/helm-release.yaml
+++ b/cluster/apps/minio/helm-release.yaml
@@ -60,11 +60,27 @@ spec:
                   periodSeconds: 5
                   failureThreshold: 60
               liveness:
+                enabled: true
+                custom: true
                 spec:
+                  httpGet:
+                    path: /minio/health/live
+                    port: 9000
                   initialDelaySeconds: 0
                   timeoutSeconds: 1
                   periodSeconds: 60
                   failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /minio/health/ready
+                    port: 9000
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/mosquitto/helm-release.yaml
+++ b/cluster/apps/mosquitto/helm-release.yaml
@@ -54,6 +54,27 @@ spec:
         mountPath: /mosquitto/configinc
         accessMode: ReadWriteOnce
         size: 100Mi
+    probes:
+      liveness:
+        enabled: true
+        custom: true
+        spec:
+          tcpSocket:
+            port: 1883
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+      readiness:
+        enabled: true
+        custom: true
+        spec:
+          tcpSocket:
+            port: 1883
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
     resources:
       requests:
         memory: 20Mi

--- a/cluster/apps/music-assistant/helm-release.yaml
+++ b/cluster/apps/music-assistant/helm-release.yaml
@@ -42,6 +42,27 @@ spec:
               limits:
                 memory: 2048Mi
                 cpu: 500m
+            probes:
+              startup:
+                spec:
+                  initialDelaySeconds: 0
+                  timeoutSeconds: 1
+                  periodSeconds: 5
+                  failureThreshold: 30
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/navidrome/helm-release.yaml
+++ b/cluster/apps/navidrome/helm-release.yaml
@@ -47,6 +47,27 @@ spec:
               limits:
                 memory: 350Mi
                 cpu: 1000m
+            probes:
+              startup:
+                spec:
+                  initialDelaySeconds: 0
+                  timeoutSeconds: 1
+                  periodSeconds: 5
+                  failureThreshold: 30
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/networking/authelia/helm-release.yaml
+++ b/cluster/apps/networking/authelia/helm-release.yaml
@@ -52,6 +52,28 @@ spec:
                   ## This means it has a maximum of 8*60=480 seconds to start up before it fails
                   periodSeconds: 8
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: 9091
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: 9091
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/node-red/helm-release.yaml
+++ b/cluster/apps/node-red/helm-release.yaml
@@ -53,6 +53,29 @@ spec:
         accessMode: "ReadWriteOnce"
         mountPath: /data
         size: "2Gi"
+    probes:
+      liveness:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /
+            port: 1880
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+      readiness:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /
+            port: 1880
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
     resources:
       requests:
         memory: 250Mi

--- a/cluster/apps/obsidian-couchdb/helm-release.yaml
+++ b/cluster/apps/obsidian-couchdb/helm-release.yaml
@@ -55,6 +55,29 @@ spec:
               limits:
                 memory: 256Mi
                 cpu: 500m
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /_up
+                    port: 5984
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /_up
+                    port: 5984
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         ports:

--- a/cluster/apps/prowlarr/helm-release.yaml
+++ b/cluster/apps/prowlarr/helm-release.yaml
@@ -53,6 +53,20 @@ spec:
                   ## This means it has a maximum of 8*60=480 seconds to start up before it fails
                   periodSeconds: 8
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/radarr/helm-release.yaml
+++ b/cluster/apps/radarr/helm-release.yaml
@@ -52,6 +52,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/scrypted/helm-release.yaml
+++ b/cluster/apps/scrypted/helm-release.yaml
@@ -36,6 +36,26 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 5
           failureThreshold: 100
+      liveness:
+        enabled: true
+        custom: true
+        spec:
+          tcpSocket:
+            port: 11080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+      readiness:
+        enabled: true
+        custom: true
+        spec:
+          tcpSocket:
+            port: 11080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/cluster/apps/shopping-cards/helm-release.yaml
+++ b/cluster/apps/shopping-cards/helm-release.yaml
@@ -50,6 +50,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/slskd/helm-release.yaml
+++ b/cluster/apps/slskd/helm-release.yaml
@@ -69,6 +69,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/sonarr/helm-release.yaml
+++ b/cluster/apps/sonarr/helm-release.yaml
@@ -52,6 +52,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/tesla-fleet/helm-release.yaml
+++ b/cluster/apps/tesla-fleet/helm-release.yaml
@@ -50,6 +50,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/teslamate/helm-release-backend.yaml
+++ b/cluster/apps/teslamate/helm-release-backend.yaml
@@ -50,6 +50,21 @@ spec:
               limits:
                 memory: 500Mi
                 cpu: 1000m
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/teslamate/helm-release-grafana.yaml
+++ b/cluster/apps/teslamate/helm-release-grafana.yaml
@@ -47,6 +47,21 @@ spec:
               limits:
                 memory: 500Mi
                 cpu: 1000m
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/transmission/helm-release.yaml
+++ b/cluster/apps/transmission/helm-release.yaml
@@ -45,6 +45,27 @@ spec:
               limits:
                 memory: 1024Mi
                 cpu: 1500m
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 9091
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 9091
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
           gluetun:
             image:
               repository: ghcr.io/qdm12/gluetun

--- a/cluster/apps/tvheadend/helm-release.yaml
+++ b/cluster/apps/tvheadend/helm-release.yaml
@@ -44,6 +44,21 @@ spec:
             securityContext:
               # Privileged securityContext required by USB devices accessed directly through the host machine
               privileged: true
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/unifi/helm-release.yaml
+++ b/cluster/apps/unifi/helm-release.yaml
@@ -44,6 +44,21 @@ spec:
               limits:
                 memory: 2048Mi
                 cpu: 500m
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/unpoller/helm-release.yaml
+++ b/cluster/apps/unpoller/helm-release.yaml
@@ -37,6 +37,29 @@ spec:
               limits:
                 memory: 500Mi
                 cpu: 500m
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /metrics
+                    port: 9130
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /metrics
+                    port: 9130
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
 
     service:
       main:

--- a/cluster/apps/uptime-kuma/helm-release.yaml
+++ b/cluster/apps/uptime-kuma/helm-release.yaml
@@ -42,6 +42,20 @@ spec:
                   ## This means it has a maximum of 8*60=480 seconds to start up before it fails
                   periodSeconds: 8
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/vaultwarden/helm-release.yaml
+++ b/cluster/apps/vaultwarden/helm-release.yaml
@@ -70,6 +70,29 @@ spec:
         accessMode: "ReadWriteOnce"
         mountPath: /config
         size: "5Gi"
+    probes:
+      liveness:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /alive
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+      readiness:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /alive
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
     resources:
       requests:
         cpu: 100m

--- a/cluster/apps/ygege/helm-release.yaml
+++ b/cluster/apps/ygege/helm-release.yaml
@@ -52,6 +52,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/yubal/helm-release.yaml
+++ b/cluster/apps/yubal/helm-release.yaml
@@ -73,6 +73,20 @@ spec:
                   timeoutSeconds: 1
                   periodSeconds: 5
                   failureThreshold: 60
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true

--- a/cluster/apps/zigbee2mqtt/helm-release.yaml
+++ b/cluster/apps/zigbee2mqtt/helm-release.yaml
@@ -45,6 +45,21 @@ spec:
             securityContext:
               # Privileged securityContext required by USB devices accessed directly through the host machine
               privileged: true
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
     service:
       main:
         enabled: true


### PR DESCRIPTION
## Problème identifié

La grande majorité des applications du cluster ne définissaient que des `startupProbe`, sans `livenessProbe` ni `readinessProbe`. En cas de freeze applicatif (boucle infinie, deadlock, etc.), Kubernetes ne détecte pas l'anomalie et le pod n'est pas redémarré automatiquement. De même, le trafic peut être routé vers un pod non encore prêt à répondre.

## Solution

Ajout de probes `liveness` et `readiness` sur l'ensemble des applications :

- **livenessProbe** : vérification HTTP (ou TCP selon l'app) toutes les 30s avec un délai initial de 30s ; redémarre le pod si échec
- **readinessProbe** : vérification HTTP (ou TCP) toutes les 10s ; retire le pod du service si échec, sans le redémarrer

Les endpoints utilisés correspondent aux endpoints de santé natifs de chaque application (ex: `/health`, `/ping`, `/api/health`, etc.).

## Applications couvertes (39 apps)

- **Arr stack** : Jellyseerr, Lidarr, Maintainerr, Prowlarr, Radarr, Sonarr
- **Média** : Backrest, Jellyfin, Music Assistant, Navidrome, Uptime Kuma
- **Domotique** : ESPHome, Home Assistant, Node-RED
- **Réseau/Auth** : AdGuard Home, Authelia
- **IoT/MQTT** : Mosquitto (TCP), Zigbee2MQTT
- **Divers** : Flaresolverr, Heimdall, Joal, KitchenVault, Memos, MinIO, Obsidian CouchDB, Scrypted, Shopping Cards, Slskd, Tesla Fleet, Teslamate, Transmission, TVHeadend, Unifi, Unpoller, Vaultwarden, Ygege, Yubal

## Fichiers modifiés

39 fichiers `helm-release.yaml` dans `cluster/apps/`