### PR TITLE
feat: enable image digest pinning in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,12 +65,27 @@
         'docker',
       ],
       enabled: true,
+      pinDigests: true,
       commitMessageTopic: 'container image {{depName}}',
       commitMessageExtra: 'to {{#if isSingleVersion}}v{{{newVersion}}}{{else}}{{{newValue}}}{{/if}}',
       matchUpdateTypes: [
         'major',
         'minor',
         'patch',
+        'digest',
+      ],
+    },
+    {
+      matchDatasources: [
+        'docker',
+      ],
+      matchUpdateTypes: [
+        'pin',
+        'digest',
+      ],
+      labels: [
+        'renovate/image',
+        'dep/pin',
       ],
     },
     {


### PR DESCRIPTION
## Problème identifié

Toutes les images container du cluster sont référencées par tag (ex: `v1.9.14`). Un tag Docker n'est pas immuable : il peut être réécrit par le mainteneur de l'image, ce qui permettrait le déploiement silencieux d'une image malveillante ou corrompue sans aucune modification visible dans Git.

## Solution

Activation du `pinDigests` dans Renovate pour les images Docker. Renovate va automatiquement ouvrir des PRs pour :

1. Ajouter un digest SHA256 à chaque image existante (ex: `image:v1.9.14@sha256:abc...`)
2. Maintenir ces digests à jour à chaque nouvelle publication

Configuration ajoutée dans `.github/renovate.json5` :
- `pinDigests: true` sur le gestionnaire `docker`
- Règle d'automerge pour les updates de type `pin` et `digest` (pas de revue manuelle nécessaire)
- Labels dédiés : `renovate/image`, `dep/pin`

## Impact

Les images seront ancrées à un contenu précis et immuable. Les mises à jour de digest seront gérées automatiquement par Renovate.

## Fichiers modifiés

- `.github/renovate.json5`