### PR TITLE
chore(renovate): add schedule, minimumReleaseAge, automerge and security alerts

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,21 @@
     'prIgnoreNotification',
   ],
   rebaseWhen: 'conflicted',
+  schedule: [
+    'before 9am on Monday',
+  ],
+  minimumReleaseAge: '3 days',
+  osvVulnerabilityAlerts: true,
+  vulnerabilityAlerts: {
+    labels: [
+      'security',
+    ],
+    automerge: true,
+    minimumReleaseAge: null,
+    schedule: [
+      'at any time',
+    ],
+  },
   'helm-values': {
     fileMatch: [
       'cluster/.+/helm-release\\.yaml$',
@@ -72,6 +87,37 @@
         'minor',
         'patch',
       ],
+    },
+    {
+      matchDatasources: [
+        'docker',
+        'helm',
+      ],
+      matchUpdateTypes: [
+        'patch',
+      ],
+      automerge: true,
+      minimumReleaseAge: '3 days',
+    },
+    {
+      matchDatasources: [
+        'docker',
+        'helm',
+      ],
+      matchUpdateTypes: [
+        'minor',
+      ],
+      minimumReleaseAge: '7 days',
+    },
+    {
+      matchDatasources: [
+        'docker',
+        'helm',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      dependencyDashboardApproval: true,
     },
     {
       matchDatasources: [


### PR DESCRIPTION
## Problème identifié

La configuration Renovate du dépôt manquait de plusieurs garde-fous importants :

1. **Aucune fenêtre de maintenance** : les PRs de mise à jour pouvaient être ouvertes n'importe quand, y compris en plein milieu de la semaine
2. **Pas de période de stabilisation** : une version pouvait être déployée immédiatement après publication, avant que des régressions connues soient signalées dans la communauté
3. **Alertes de sécurité non configurées** : les vulnérabilités CVE connues n'étaient pas automatiquement traitées
4. **Mise à jour majeures sans frein** : elles arrivaient sans approbation explicite requise

## Solution

Ajout des paramètres suivants dans `.github/renovate.json5` :

- **`schedule: ['before 9am on Monday']`** : toutes les mises à jour groupées le lundi matin
- **`minimumReleaseAge: '3 days'`** : attendre 3 jours après la publication avant de proposer une mise à jour (patch)
- **`minimumReleaseAge: '7 days'`** : 7 jours pour les mises à jour mineures
- **`osvVulnerabilityAlerts`** + **`vulnerabilityAlerts`** : automerge immédiat des correctifs de sécurité (CVE), sans attendre la fenêtre de maintenance
- **`dependencyDashboardApproval: true`** pour les majors : validation manuelle requise sur le tableau de bord Renovate
- **`automerge: true`** pour les patches : fusion automatique après CI verte

## Fichiers modifiés

- `.github/renovate.json5`