### PR TITLE
feat: add PodDisruptionBudgets for Traefik and Authelia

### DIFF
--- a/cluster/apps/networking/authelia/kustomization.yaml
+++ b/cluster/apps/networking/authelia/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - helm-release.yaml
   - middleware.yaml
+  - pdb.yaml
   

--- a/cluster/apps/networking/authelia/pdb.yaml
+++ b/cluster/apps/networking/authelia/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: authelia
+  namespace: networking
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authelia

--- a/cluster/apps/networking/traefik/kustomization.yaml
+++ b/cluster/apps/networking/traefik/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helm-release.yaml
+  - pdb.yaml
   - tls-store
   - plugins/crowdsec-bouncer.yaml
   - monitoring/servicemonitor.yaml

--- a/cluster/apps/networking/traefik/pdb.yaml
+++ b/cluster/apps/networking/traefik/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: traefik
+  namespace: networking
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: traefik


### PR DESCRIPTION
## Problème identifié

Les deux composants réseau critiques du cluster — Traefik (ingress controller) et Authelia (portail d'authentification) — ne disposaient d'aucun `PodDisruptionBudget`. Lors d'opérations de maintenance (drain d'un nœud, mise à jour de k3s, redémarrage planifié), Kubernetes peut déplacer tous les pods simultanément, provoquant une interruption de service.

## Solution

Création de `PodDisruptionBudget` pour chacun des deux composants :

- **Traefik** : `minAvailable: 1` — au moins une instance doit rester disponible pendant toute opération de maintenance
- **Authelia** : `maxUnavailable: 1` — au plus une instance peut être indisponible à la fois

## Impact

Lors des opérations de drain ou de mise à jour des nœuds, Kubernetes respectera ces contraintes et attendra qu'une nouvelle instance soit prête avant d'en terminer une existante.

## Fichiers modifiés

- `cluster/apps/networking/traefik/pdb.yaml` (nouveau)
- `cluster/apps/networking/traefik/kustomization.yaml`
- `cluster/apps/networking/authelia/pdb.yaml` (nouveau)
- `cluster/apps/networking/authelia/kustomization.yaml`