### PR TITLE
fix(restic): set imagePullPolicy to IfNotPresent on all CronJobs

### DIFF
--- a/cluster/apps/restic/bitwarden-db-backup.yaml
+++ b/cluster/apps/restic/bitwarden-db-backup.yaml
@@ -12,7 +12,7 @@ spec:
           containers:
             - name: restic-bitwarden-db
               image: ghcr.io/seblaporte/restic:1.1.0
-              imagePullPolicy: Always
+              imagePullPolicy: IfNotPresent
               env:
                 - name: RESTIC_PASSWORD
                   value: ${SECRET_RESTIC_PASSWORD}

--- a/cluster/apps/restic/home-assistant-db-backup.yaml
+++ b/cluster/apps/restic/home-assistant-db-backup.yaml
@@ -12,7 +12,7 @@ spec:
           containers:
             - name: restic-home-assistant-db
               image: ghcr.io/seblaporte/restic:1.1.0
-              imagePullPolicy: Always
+              imagePullPolicy: IfNotPresent
               env:
                 - name: RESTIC_PASSWORD
                   value: ${SECRET_RESTIC_PASSWORD}

--- a/cluster/apps/restic/k3s-db-backup.yaml
+++ b/cluster/apps/restic/k3s-db-backup.yaml
@@ -12,7 +12,7 @@ spec:
           containers:
             - name: restic-k3s-db
               image: ghcr.io/seblaporte/restic:1.1.0
-              imagePullPolicy: Always
+              imagePullPolicy: IfNotPresent
               env:
                 - name: RESTIC_PASSWORD
                   value: ${SECRET_RESTIC_PASSWORD}

--- a/cluster/apps/restic/prowlarr-db-backup.yaml
+++ b/cluster/apps/restic/prowlarr-db-backup.yaml
@@ -12,7 +12,7 @@ spec:
           containers:
             - name: restic-prowlarr-db
               image: ghcr.io/seblaporte/restic:1.1.0
-              imagePullPolicy: Always
+              imagePullPolicy: IfNotPresent
               env:
                 - name: RESTIC_PASSWORD
                   value: ${SECRET_RESTIC_PASSWORD}

--- a/cluster/apps/restic/radarr-db-backup.yaml
+++ b/cluster/apps/restic/radarr-db-backup.yaml
@@ -12,7 +12,7 @@ spec:
           containers:
             - name: restic-radarr-db
               image: ghcr.io/seblaporte/restic:1.1.0
-              imagePullPolicy: Always
+              imagePullPolicy: IfNotPresent
               env:
                 - name: RESTIC_PASSWORD
                   value: ${SECRET_RESTIC_PASSWORD}

--- a/cluster/apps/restic/sonarr-db-backup.yaml
+++ b/cluster/apps/restic/sonarr-db-backup.yaml
@@ -12,7 +12,7 @@ spec:
           containers:
             - name: restic-sonarr-db
               image: ghcr.io/seblaporte/restic:1.1.0
-              imagePullPolicy: Always
+              imagePullPolicy: IfNotPresent
               env:
                 - name: RESTIC_PASSWORD
                   value: ${SECRET_RESTIC_PASSWORD}

--- a/cluster/apps/restic/teslamate-db-backup.yaml
+++ b/cluster/apps/restic/teslamate-db-backup.yaml
@@ -12,7 +12,7 @@ spec:
           containers:
             - name: restic-teslamate-db
               image: ghcr.io/seblaporte/restic:1.1.0
-              imagePullPolicy: Always
+              imagePullPolicy: IfNotPresent
               env:
                 - name: RESTIC_PASSWORD
                   value: ${SECRET_RESTIC_PASSWORD}

--- a/cluster/apps/restic/volume-backup.yaml
+++ b/cluster/apps/restic/volume-backup.yaml
@@ -12,7 +12,7 @@ spec:
           containers:
             - name: restic-volume
               image: ghcr.io/seblaporte/restic:1.1.0
-              imagePullPolicy: Always
+              imagePullPolicy: IfNotPresent
               env:
                 - name: RESTIC_PASSWORD
                   value: ${SECRET_RESTIC_PASSWORD}


### PR DESCRIPTION
## Problème identifié

Tous les CronJobs de backup restic utilisaient `imagePullPolicy: Always`. Cette configuration force Kubernetes à contacter le registry Docker à chaque exécution du job pour vérifier si l'image a changé. Pour des backups planifiés (souvent nocturnes), cela présente deux risques :

1. **Dépendance réseau** : si le registry est inaccessible au moment de l'exécution, le pod ne démarre pas et le backup échoue — même si l'image est déjà présente localement
2. **Latence inutile** : temps supplémentaire à chaque exécution pour la vérification

## Solution

Remplacement de `imagePullPolicy: Always` par `imagePullPolicy: IfNotPresent` sur l'ensemble des CronJobs restic. L'image sera utilisée depuis le cache local si elle est déjà présente, et téléchargée uniquement si absente.

Les mises à jour d'image restent gérées par Renovate qui modifiera le tag/digest, ce qui déclenchera automatiquement un nouveau pull.

## Fichiers modifiés

8 fichiers CronJob dans `cluster/apps/restic/`