### PR TITLE
feat(kitchenvault): add iSCSI persistence for cookidoo /data directory

### DIFF
--- a/cluster/apps/kitchenvault/base/helm-release-cookidoo.yaml
+++ b/cluster/apps/kitchenvault/base/helm-release-cookidoo.yaml
@@ -82,3 +82,11 @@ spec:
             enabled: true
             port: 8001
             protocol: TCP
+    persistence:
+      data:
+        enabled: true
+        storageClass: "synology-iscsi-storage"
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        globalMounts:
+          - path: /data


### PR DESCRIPTION
## Summary

- Adds a `persistence` block to `helm-release-cookidoo.yaml`
- Provisions a 1Gi iSCSI PVC via `synology-iscsi-storage` StorageClass
- Mounts the volume at `/data` in the cookidoo container to persist data across pod restarts

## Test plan

- [ ] Flux reconciles the HelmRelease without errors
- [ ] `kubectl get pvc -n kitchenvault` shows `kitchenvault-cookidoo-data` as `Bound`
- [ ] `kubectl describe pod -n kitchenvault -l app.kubernetes.io/name=kitchenvault-cookidoo` shows volume mounted at `/data`
- [ ] Data written to `/data` survives a pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)