### PR TITLE
fix(kitchenvault): allow independent image tag override for dev

### DIFF
--- a/cluster/apps/kitchenvault/dev/kustomization.yaml
+++ b/cluster/apps/kitchenvault/dev/kustomization.yaml
@@ -14,3 +14,15 @@ patches:
     target:
       kind: HelmRelease
       name: kitchenvault-frontend
+  - path: patch-backend-tag.yaml
+    target:
+      kind: HelmRelease
+      name: kitchenvault-backend
+  - path: patch-frontend-tag.yaml
+    target:
+      kind: HelmRelease
+      name: kitchenvault-frontend
+  - path: patch-cookidoo-tag.yaml
+    target:
+      kind: HelmRelease
+      name: kitchenvault-cookidoo

--- a/cluster/apps/kitchenvault/dev/patch-backend-tag.yaml
+++ b/cluster/apps/kitchenvault/dev/patch-backend-tag.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kitchenvault-backend
+spec:
+  values:
+    controllers:
+      main:
+        containers:
+          main:
+            image:
+              tag: "manual"

--- a/cluster/apps/kitchenvault/dev/patch-cookidoo-tag.yaml
+++ b/cluster/apps/kitchenvault/dev/patch-cookidoo-tag.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kitchenvault-cookidoo
+spec:
+  values:
+    controllers:
+      main:
+        containers:
+          main:
+            image:
+              tag: "manual"

--- a/cluster/apps/kitchenvault/dev/patch-frontend-tag.yaml
+++ b/cluster/apps/kitchenvault/dev/patch-frontend-tag.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kitchenvault-frontend
+spec:
+  values:
+    controllers:
+      main:
+        containers:
+          main:
+            image:
+              tag: "manual"


### PR DESCRIPTION
## Summary
- Les 3 HelmRelease KitchenVault (backend, frontend, cookidoo) partageaient le même tag `manual` défini uniquement dans `base/`, empêchant de faire évoluer `dev` indépendamment de `production`.
- Ajout de 3 fichiers `dev/patch-*-tag.yaml` (backend/frontend/cookidoo) suivant le pattern `patches:` / `target: {kind: HelmRelease, name: ...}` déjà utilisé pour les patches d'ingress.
- Mise à jour de `dev/kustomization.yaml` pour référencer ces patches.
- `production` n'a pas besoin de patch : il continue de suivre directement le tag défini dans `base/` (pas de changement sur `production/kustomization.yaml`).
- `base/` conserve `tag: "manual"` comme fallback, non modifié.

## Test plan
- [x] `kubectl kustomize cluster/apps/kitchenvault/dev` — build OK, `tag: manual` présent pour backend, frontend, cookidoo
- [x] `kubectl kustomize cluster/apps/kitchenvault/production` — build OK, `tag: manual` (hérité de `base/`) pour backend, frontend, cookidoo
- [x] Aucune modification de `base/`, de `production/`, ni du repo KitchenVault

🤖 Generated with [Claude Code](https://claude.com/claude-code)