### PR TITLE
fix(kitchenvault): bump dev image tag to 2026.8.1

### DIFF
--- a/cluster/apps/kitchenvault/dev/patch-backend-tag.yaml
+++ b/cluster/apps/kitchenvault/dev/patch-backend-tag.yaml
@@ -10,4 +10,4 @@ spec:
         containers:
           main:
             image:
-              tag: "2026.8.0"
+              tag: "2026.8.1"

--- a/cluster/apps/kitchenvault/dev/patch-cookidoo-tag.yaml
+++ b/cluster/apps/kitchenvault/dev/patch-cookidoo-tag.yaml
@@ -10,4 +10,4 @@ spec:
         containers:
           main:
             image:
-              tag: "2026.8.0"
+              tag: "2026.8.1"

--- a/cluster/apps/kitchenvault/dev/patch-frontend-tag.yaml
+++ b/cluster/apps/kitchenvault/dev/patch-frontend-tag.yaml
@@ -10,4 +10,4 @@ spec:
         containers:
           main:
             image:
-              tag: "2026.8.0"
+              tag: "2026.8.1"


### PR DESCRIPTION
## Summary
- Bumps the KitchenVault `dev` overlay's three image tags (`backend`, `frontend`, `cookidoo`) from `2026.8.0` to `2026.8.1`, matching the new release just published to GHCR.
- Production is untouched — it continues to track `base/`'s `"manual"` tag directly, per the design introduced in #936.

## Test plan
- [x] `kubectl kustomize cluster/apps/kitchenvault/dev` renders all three HelmReleases with `tag: 2026.8.1`
- [x] `kubectl kustomize cluster/apps/kitchenvault/production` unaffected (still `tag: manual`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)